### PR TITLE
Fixed Active Tab Highlight

### DIFF
--- a/src/vscode-tab-header/vscode-tab-header.styles.ts
+++ b/src/vscode-tab-header/vscode-tab-header.styles.ts
@@ -47,7 +47,7 @@ const styles: CSSResultGroup = [
 
     .wrapper.panel.active,
     .wrapper.panel:hover {
-      color: var(--vscode-panelTitle-inactiveForeground);
+      color: var(--vscode-panelTitle-activeForeground);
     }
 
     :host([panel]) .wrapper {


### PR DESCRIPTION
Active tab highlights previously showed as inactive. This commit fixes this bug.