### PR TITLE
Split layout: controlled handle position and event

### DIFF
--- a/src/vscode-split-layout/vscode-split-layout.ts
+++ b/src/vscode-split-layout/vscode-split-layout.ts
@@ -1,4 +1,4 @@
-import {html, TemplateResult} from 'lit';
+import {html, PropertyValues, TemplateResult} from 'lit';
 import {
   customElement,
   property,
@@ -74,6 +74,12 @@ export class VscodeSplitLayout extends VscElement {
     this._initPosition();
   }
 
+  protected updated(_changedProperties: PropertyValues): void {
+    if(_changedProperties.has("split")) {
+      this._initPosition();
+    }
+  }
+
   /** @internal */
   initializeResizeHandler() {
     this._initPosition();
@@ -103,9 +109,15 @@ export class VscodeSplitLayout extends VscElement {
       this._startPaneRight = ((maxPos - pos) / width) * 100;
       this._endPaneLeft = (pos / width) * 100;
       this._handleLeft = (pos / width) * 100;
+      this._startPaneBottom = 0;
+      this._endPaneTop = 0;
+      this._handleTop = 0;
     }
 
     if (this.split === 'horizontal') {
+      this._startPaneRight = 0;
+      this._endPaneLeft = 0;
+      this._handleLeft = 0;
       this._startPaneBottom = ((maxPos - pos) / height) * 100;
       this._endPaneTop = (pos / height) * 100;
       this._handleTop = (pos / height) * 100;

--- a/src/vscode-split-layout/vscode-split-layout.ts
+++ b/src/vscode-split-layout/vscode-split-layout.ts
@@ -10,6 +10,8 @@ import {styleMap} from 'lit/directives/style-map.js';
 import {VscElement} from '../includes/VscElement.js';
 import styles from './vscode-split-layout.styles.js';
 
+export type VscSplitLayoutSizeChangedEvent = CustomEvent<{newSize: number}>;
+
 /**
  * @cssprop [--hover-border=var(--vscode-sash-hoverBorder)]
  */
@@ -85,6 +87,17 @@ export class VscodeSplitLayout extends VscElement {
     this._initPosition();
   }
 
+  private _dispatchSizeChanged() {
+    this.dispatchEvent(
+      new CustomEvent('vsc-split-layout-size-changed', {
+        detail: {
+          newSize: this.split === "vertical" ? this._handleLeft : this._handleTop,
+        },
+        composed: true,
+      }) as VscSplitLayoutSizeChangedEvent
+    );
+  }
+
   private _initPosition() {
     this._boundRect = this.getBoundingClientRect();
     const {height, width} = this._boundRect;
@@ -122,6 +135,8 @@ export class VscodeSplitLayout extends VscElement {
       this._endPaneTop = (pos / height) * 100;
       this._handleTop = (pos / height) * 100;
     }
+
+    this._dispatchSizeChanged();
   }
 
   private _handleMouseOver() {
@@ -202,6 +217,8 @@ export class VscodeSplitLayout extends VscElement {
       this._startPaneBottom = startPaneBottomPercentage;
       this._endPaneTop = this._handleTop;
     }
+
+    this._dispatchSizeChanged();
   };
 
   private _handleDblClick() {
@@ -223,6 +240,20 @@ export class VscodeSplitLayout extends VscElement {
         e.initializeResizeHandler();
       }
     });
+  }
+
+  public setSize(newSize: number): void {
+    const {height, width} = this._boundRect;
+
+    if(this.split === "vertical") {
+      this._handleLeft = newSize;
+      this._endPaneLeft = this._handleLeft;
+      this._startPaneRight = (Math.max(0, width - this._handleLeft * width / 100) / width) * 100
+    } else {
+      this._handleTop = newSize;
+      this._endPaneTop = this._handleTop;
+      this._startPaneBottom = (Math.max(0, height - this._handleTop * height / 100) / height) * 100
+    }
   }
 
   render(): TemplateResult {
@@ -291,5 +322,9 @@ export class VscodeSplitLayout extends VscElement {
 declare global {
   interface HTMLElementTagNameMap {
     'vscode-split-layout': VscodeSplitLayout;
+  }
+
+  interface GlobalEventHandlersEventMap {
+    'vsc-split-layout-size-changed': VscSplitLayoutSizeChangedEvent;
   }
 }

--- a/src/vscode-split-layout/vscode-split-layout.ts
+++ b/src/vscode-split-layout/vscode-split-layout.ts
@@ -85,17 +85,15 @@ export class VscodeSplitLayout extends VscElement {
     if (_changedProperties.has("split")) {
       this._initPosition();
     } else if (_changedProperties.has("position")) {
-      const {height, width} = this._boundRect;
-
       if(this.split === "vertical") {
         this._handleLeft = this.position;
         this._endPaneLeft = this._handleLeft;
-        this._startPaneRight = (Math.max(0, width - this._handleLeft * width / 100) / width) * 100
+        this._startPaneRight = 100 - this._handleLeft;
       } else {
         this._handleTop = this.position;
         this._endPaneTop = this._handleTop;
-        this._startPaneBottom = (Math.max(0, height - this._handleTop * height / 100) / height) * 100
-      }  
+        this._startPaneBottom = 100 - this._handleTop;
+      }
     }
   }
 


### PR DESCRIPTION
  Hello,
  I've had the need to handle the split layout position programmatically, and because of this I've made some modifications in a local branch. I have thought it could be useful for the component in general.

  The change I'm proposing is a new property and event for the split layout:
- a `position` property, as a 0-100 percentage representing the position of the handle, that can be both read and written;
- a `vsc-split-layout-position-changed` event that is raised whenever the position of the handle changes.

If there are better ways to approach this feature, I'm available to make changes!