### PR TITLE
First Multi-Select Option Set Bug

### DIFF
--- a/src/vscode-multi-select/vscode-multi-select.ts
+++ b/src/vscode-multi-select/vscode-multi-select.ts
@@ -85,7 +85,7 @@ export class VscodeMultiSelect
     this._selectedIndexes = [];
 
     sanitizedVal.forEach((v) => {
-      if (this._valueOptionIndexMap[v]) {
+      if (typeof this._valueOptionIndexMap[v] === 'number') {
         this._selectedIndexes.push(this._valueOptionIndexMap[v]);
         this._options[this._valueOptionIndexMap[v]].selected = true;
       }


### PR DESCRIPTION
Due to the initial option having an index of 0 for the `_valueOptionIndexMap`, a conversion check would fail. This resulted in selected values not being correctly updated. This fix checks for a number instead of truthiness to allow setting multi-select values programmatically.