### PR TITLE
Fix bug with element disconnection

### DIFF
--- a/src/vscode-table/vscode-table.test.ts
+++ b/src/vscode-table/vscode-table.test.ts
@@ -6,4 +6,11 @@ describe('vscode-table', () => {
     const el = document.createElement('vscode-table');
     expect(el).to.instanceOf(VscodeTable);
   });
+
+  it('should not throw when removed from the DOM', () => {
+    const el = document.createElement('vscode-table');
+    document.body.append(el);
+
+    expect(() => el.remove()).not.to.throw();
+  });
 });

--- a/src/vscode-table/vscode-table.ts
+++ b/src/vscode-table/vscode-table.ts
@@ -138,8 +138,8 @@ export class VscodeTable extends VscElement {
    */
   private _sashHovers: boolean[] = [];
   private _columns: string[] = [];
-  private _componentResizeObserver!: ResizeObserver;
-  private _headerResizeObserver!: ResizeObserver;
+  private _componentResizeObserver?: ResizeObserver;
+  private _headerResizeObserver?: ResizeObserver;
   private _bodyResizeObserver?: ResizeObserver;
   private _activeSashElementIndex = -1;
   private _activeSashCursorOffset = 0;
@@ -170,8 +170,8 @@ export class VscodeTable extends VscElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._componentResizeObserver.unobserve(this);
-    this._componentResizeObserver.disconnect();
+    this._componentResizeObserver?.unobserve(this);
+    this._componentResizeObserver?.disconnect();
     this._bodyResizeObserver?.disconnect();
   }
 


### PR DESCRIPTION
Noticed when testing with https://testing-library.com/docs/react-testing-library/intro/ - test cleanup was causing the following error:

```
@vscode-bicep-ui/deploy-pane:test: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
@vscode-bicep-ui/deploy-pane:test: TypeError: Cannot read properties of undefined (reading 'unobserve')
@vscode-bicep-ui/deploy-pane:test:  ❯ VscodeTable.disconnectedCallback ../../node_modules/@vscode-elements/elements/src/vscode-table/vscode-table.ts:171:35
@vscode-bicep-ui/deploy-pane:test:  ❯ VscodeTable.invokeTheCallbackFunction ../../node_modules/jsdom/lib/jsdom/living/generated/Function.js:19:26
@vscode-bicep-ui/deploy-pane:test:  ❯ invokeCEReactions ../../node_modules/jsdom/lib/jsdom/living/helpers/custom-elements.js:190:31
@vscode-bicep-ui/deploy-pane:test:  ❯ ceReactionsPostSteps ../../node_modules/jsdom/lib/jsdom/living/helpers/custom-elements.js:54:3
@vscode-bicep-ui/deploy-pane:test:  ❯ HTMLDivElement.removeChild ../../node_modules/jsdom/lib/jsdom/living/generated/Node.js:474:9
@vscode-bicep-ui/deploy-pane:test:  ❯ removeChildFromContainer ../../node_modules/react-dom/cjs/react-dom.development.js:11105:15
@vscode-bicep-ui/deploy-pane:test:  ❯ commitDeletionEffectsOnFiber ../../node_modules/react-dom/cjs/react-dom.development.js:24065:15
@vscode-bicep-ui/deploy-pane:test:  ❯ recursivelyTraverseDeletionEffects ../../node_modules/react-dom/cjs/react-dom.development.js:24028:5
@vscode-bicep-ui/deploy-pane:test:  ❯ commitDeletionEffectsOnFiber ../../node_modules/react-dom/cjs/react-dom.development.js:24157:9
@vscode-bicep-ui/deploy-pane:test:  ❯ commitDeletionEffects ../../node_modules/react-dom/cjs/react-dom.development.js:24015:5
@vscode-bicep-ui/deploy-pane:test: 
@vscode-bicep-ui/deploy-pane:test: This error originated in "src/components/App.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
@vscode-bicep-ui/deploy-pane:test: The latest test that might've caused the error is "what-ifs a deployment". It might mean one of the following:
@vscode-bicep-ui/deploy-pane:test: - The error was thrown, while Vitest was running this test.
@vscode-bicep-ui/deploy-pane:test: - If the error occurred after the test had been completed, this was the last documented test before it was thrown.
```