### PR TITLE
FIx textfield value

### DIFF
--- a/src/vscode-textfield/vscode-textfield.test.ts
+++ b/src/vscode-textfield/vscode-textfield.test.ts
@@ -16,7 +16,7 @@ describe('vscode-textfield', () => {
     expect(el).shadowDom.to.equal(
       `
       <slot name="content-before"></slot>
-      <input aria-label="" id="input" type="text" value="">
+      <input aria-label="" id="input" type="text">
       <slot name="content-after"></slot>
       `
     );

--- a/src/vscode-textfield/vscode-textfield.ts
+++ b/src/vscode-textfield/vscode-textfield.ts
@@ -379,7 +379,7 @@ export class VscodeTextfield
         ?readonly=${this.readonly}
         ?required=${this.required}
         step=${ifDefined(this.step)}
-        value=${ifDefined(this.type !== 'file' ? this._value : undefined)}
+        .value=${this._value}
         @blur=${this._onBlur}
         @change=${this._onChange}
         @focus=${this._onFocus}


### PR DESCRIPTION
The native `input` value property and the `value` attribute have different effects. The `value` attribute is the default value, while the property represents the actual value.