### PR TITLE
fix: resetHandlePosition upon split change

### DIFF
--- a/src/vscode-split-layout/vscode-split-layout.test.ts
+++ b/src/vscode-split-layout/vscode-split-layout.test.ts
@@ -654,6 +654,27 @@ describe('vscode-split-layout', () => {
     });
   });
 
+  it.only('should not reset handle position when split is set to the same value', async () => {
+    const el = await fixture<VscodeSplitLayout>(
+      html`<vscode-split-layout
+        style="width: 500px; height: 500px;"
+        initial-handle-position="100px"
+        split="horizontal"
+      ></vscode-split-layout>`
+    );
+
+    el.handlePosition = "200px";
+    await el.updateComplete;
+
+    const handle = el.shadowRoot!.querySelector('.handle') as HTMLDivElement;
+    expect(handle.offsetTop).to.eq(198);
+
+    el.setAttribute('split', 'horizontal');
+    await el.updateComplete;
+
+    expect(handle.offsetTop).to.eq(198);
+  });
+
   // TODO
   it('should nested instances reset when slotted content is changed');
   it('fixed pane prop changed');

--- a/src/vscode-split-layout/vscode-split-layout.test.ts
+++ b/src/vscode-split-layout/vscode-split-layout.test.ts
@@ -663,7 +663,7 @@ describe('vscode-split-layout', () => {
       ></vscode-split-layout>`
     );
 
-    el.handlePosition = "200px";
+    el.handlePosition = '200px';
     await el.updateComplete;
 
     const handle = el.shadowRoot!.querySelector('.handle') as HTMLDivElement;

--- a/src/vscode-split-layout/vscode-split-layout.ts
+++ b/src/vscode-split-layout/vscode-split-layout.ts
@@ -74,7 +74,7 @@ export class VscodeSplitLayout extends VscElement {
    */
   @property({reflect: true})
   set split(newVal: Orientation) {
-    if(this._split === newVal) {
+    if (this._split === newVal) {
       return;
     }
     this._split = newVal;

--- a/src/vscode-split-layout/vscode-split-layout.ts
+++ b/src/vscode-split-layout/vscode-split-layout.ts
@@ -74,6 +74,9 @@ export class VscodeSplitLayout extends VscElement {
    */
   @property({reflect: true})
   set split(newVal: Orientation) {
+    if(this._split === newVal) {
+      return;
+    }
     this._split = newVal;
     this.resetHandlePosition();
   }


### PR DESCRIPTION
When the "split" property of VscodeSplitLayout is set to the same value as the previous one, no handle reset should happen.