### PR TITLE
Add support for icon only buttons

### DIFF
--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -102,6 +102,7 @@ const styles: CSSResultGroup = [
       justify-content: center;
       position: relative;
       width: 100%;
+      height: 100%;
     }
 
     slot {
@@ -114,6 +115,10 @@ const styles: CSSResultGroup = [
       color: inherit;
       display: block;
       margin-right: 3px;
+    }
+
+    :host([icon-only]) .icon {
+      margin-right: 0px;
     }
 
     .icon-after {


### PR DESCRIPTION
If you have a button which includes an icon but no text, it still has the 3px margin - which results in the button being off centre

![image](https://github.com/user-attachments/assets/4e3861b4-2466-4f69-8fbd-fa244eac9635)

This change would allow for an icon-only attribute to be passed in, which avoids the 3px margin.

![image](https://github.com/user-attachments/assets/a2060298-ee5c-4edd-b596-b504817f1f50)

Another option would be to avoid this attribute and instead determine if the slot is empty.
