### PR TITLE
Update vscode-button to only apply a margin to icons if there is slotted content

### DIFF
--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -91,6 +91,10 @@ const styles: CSSResultGroup = [
       margin-left: 0;
     }
 
+    ::slotted(*:last-child) {
+      margin-right: 0;
+    }
+
     ::slotted(vscode-icon) {
       color: inherit;
     }

--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -102,6 +102,7 @@ const styles: CSSResultGroup = [
       justify-content: center;
       position: relative;
       width: 100%;
+      height: 100%;
     }
 
     slot {
@@ -110,15 +111,16 @@ const styles: CSSResultGroup = [
       height: 100%;
     }
 
-    .icon {
+    .icon, .icon-after {
       color: inherit;
       display: block;
+    }
+
+    :host(:not(:empty)) .icon {
       margin-right: 3px;
     }
 
-    .icon-after {
-      color: inherit;
-      display: block;
+    :host(:not(:empty)) .icon-after, :host([icon]) .icon-after {
       margin-left: 3px;
     }
   `,


### PR DESCRIPTION
If you have a button which includes an icon but no text, it still has the 3px margin - which results in the button being off centre

![image](https://github.com/user-attachments/assets/4e3861b4-2466-4f69-8fbd-fa244eac9635)

This change updates the CSS to only apply that 3px margin if there is slotted content.

![image](https://github.com/user-attachments/assets/a2060298-ee5c-4edd-b596-b504817f1f50)

As such for regular buttons this should be a noop, but for buttons which only specify an icon, it should correctly centre the icon in the button.

---

It also applies a height 100%, since if there is no content, this can also cause the button to get vertically squished if it is placed in a flex with other buttons.
