### PR TITLE
Allow for vscode-button-group to shrink like a button

### DIFF
--- a/src/vscode-button-group/vscode-button-group.styles.ts
+++ b/src/vscode-button-group/vscode-button-group.styles.ts
@@ -21,6 +21,7 @@ const styles: CSSResultGroup = [
 
     ::slotted(vscode-button:not(:last-child)) {
       --divider-display: block;
+      --wrapper-width: calc(100%-1px);
 
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;

--- a/src/vscode-button-group/vscode-button-group.styles.ts
+++ b/src/vscode-button-group/vscode-button-group.styles.ts
@@ -10,6 +10,7 @@ const styles: CSSResultGroup = [
       align-items: stretch;
       padding: 0;
       border: none;
+      overflow: hidden;
     }
 
     ::slotted(vscode-button:not(:first-child)) {

--- a/src/vscode-button-group/vscode-button-group.styles.ts
+++ b/src/vscode-button-group/vscode-button-group.styles.ts
@@ -21,7 +21,7 @@ const styles: CSSResultGroup = [
 
     ::slotted(vscode-button:not(:last-child)) {
       --divider-display: block;
-      --wrapper-width: calc(100%-1px);
+      --wrapper-width: calc(100% - 1px);
 
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;

--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -105,7 +105,7 @@ const styles: CSSResultGroup = [
       display: flex;
       justify-content: center;
       position: relative;
-      width: calc(100% - 2px);
+      width: calc(100% - 1px);
       height: 100%;
       padding: 1px 13px;
     }

--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -105,16 +105,16 @@ const styles: CSSResultGroup = [
       display: flex;
       justify-content: center;
       position: relative;
-      width: 100%;
+      width: calc(100% - 2px);
       height: 100%;
-      padding: 1px 13px;
+      padding: 1px 12px;
     }
 
     :host(:empty) .wrapper,
     :host([icon-only]) .wrapper {
       min-height: 24px;
       min-width: 16px;
-      padding: 1px 5px;
+      padding: 1px 4px;
     }
 
     slot {

--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -107,14 +107,14 @@ const styles: CSSResultGroup = [
       position: relative;
       width: calc(100% - 2px);
       height: 100%;
-      padding: 1px 12px;
+      padding: 1px 13px;
     }
 
     :host(:empty) .wrapper,
     :host([icon-only]) .wrapper {
       min-height: 24px;
       min-width: 16px;
-      padding: 1px 4px;
+      padding: 1px 5px;
     }
 
     slot {

--- a/src/vscode-button/vscode-button.styles.ts
+++ b/src/vscode-button/vscode-button.styles.ts
@@ -105,7 +105,7 @@ const styles: CSSResultGroup = [
       display: flex;
       justify-content: center;
       position: relative;
-      width: calc(100% - 1px);
+      width: var(--wrapper-width, 100%);
       height: 100%;
       padding: 1px 13px;
     }


### PR DESCRIPTION
If you have a `<vscode-button-group>` in a flex with limited width they don't shrink in the same way that `<vscode-button>` does.

This is very obvious if you mix `<vscode-button-group>`s and `<vscode-button>`s, for example:

![image](https://github.com/user-attachments/assets/40f56047-6032-4115-a719-f1ec156381bd)

If we set `overflow: hidden` on the group, that allows for the buttons within the group to be shrunk. We also set the width of the button to `100%-1px` to ensure the divider stays visible. I checked and we don't need to make any adjustments to padding to keep the box the same size since when the box is not constrained, the width is just as wide as it needs to be.

![image](https://github.com/user-attachments/assets/897fcd0c-e1e2-4453-9d5c-ba867d7f419c)
