### PR TITLE
Prevent option text from wrapping to multiple lines

### DIFF
--- a/src/includes/vscode-select/styles.ts
+++ b/src/includes/vscode-select/styles.ts
@@ -214,7 +214,6 @@ export default [
       font-family: var(--vscode-font-family, sans-serif);
       font-size: var(--vscode-font-size, 13px);
       font-weight: var(--vscode-font-weight, normal);
-      height: 22px;
       line-height: 18px;
       min-height: calc(var(--vscode-font-size) * 1.3);
       padding: 1px 3px;

--- a/src/includes/vscode-select/styles.ts
+++ b/src/includes/vscode-select/styles.ts
@@ -206,15 +206,14 @@ export default [
     }
 
     .option {
-      align-items: center;
       box-sizing: border-box;
       color: var(--vscode-foreground, #cccccc);
       cursor: pointer;
-      display: flex;
       font-family: var(--vscode-font-family, sans-serif);
       font-size: var(--vscode-font-size, 13px);
       font-weight: var(--vscode-font-weight, normal);
-      line-height: 18px;
+      height: 22px;
+      line-height: 20px;
       min-height: calc(var(--vscode-font-size) * 1.3);
       padding: 1px 3px;
       user-select: none;
@@ -222,6 +221,9 @@ export default [
       outline-offset: -1px;
       outline-style: solid;
       outline-width: 1px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     .option b {


### PR DESCRIPTION
Fixes an issue with multiline vscode options:

Before:
<img width="405" height="213" alt="Screenshot 2025-08-01 at 09 52 16" src="https://github.com/user-attachments/assets/1e24d0ff-36f9-41e7-8b96-18a0908b651e" />

After:
<img width="477" height="267" alt="Screenshot 2025-08-01 at 16 43 25" src="https://github.com/user-attachments/assets/2ab0fe8e-139c-4b0d-a2d3-e96b70b8cfd3" />

