### PR TITLE
fix: Table resize bug fix #503

### DIFF
--- a/src/vscode-table/vscode-table.ts
+++ b/src/vscode-table/vscode-table.ts
@@ -602,7 +602,7 @@ export class VscodeTable extends VscElement {
       this._headerCellsToResize[1].style.width = nextColCss;
     }
 
-    if (resizeBodyCells) {
+    if (resizeBodyCells && this._cellsToResize[0]) {
       this._cellsToResize[0].style.width = prevColCss;
 
       if (this._cellsToResize[1]) {


### PR DESCRIPTION
### Fixes #503

This PR applies additional guard to `_resizeColumns` method of the component in order to prevent undefined behaviour when there are no rows or cells present in the table.

```ts
private _resizeColumns(resizeBodyCells = true) {
    const {sashPos, prevSashPos, nextSashPos} = this._getSashPositions();

    const prevColW = sashPos - prevSashPos;
    const nextColW = nextSashPos - sashPos;
    const prevColCss = `${prevColW}%`;
    const nextColCss = `${nextColW}%`;

    this._headerCellsToResize[0].style.width = prevColCss;

    if (this._headerCellsToResize[1]) {
      this._headerCellsToResize[1].style.width = nextColCss;
    }

    if (resizeBodyCells && this._cellsToResize[0]) {   //introduce guard here
      this._cellsToResize[0].style.width = prevColCss;

      if (this._cellsToResize[1]) {
        this._cellsToResize[1].style.width = nextColCss;
      }
    }
  }
```