### PR TITLE
Change `@vsc-change` deprecated custom event to `@change`

### DIFF
--- a/src/vscode-radio-group/vscode-radio-group.ts
+++ b/src/vscode-radio-group/vscode-radio-group.ts
@@ -159,7 +159,7 @@ export class VscodeRadioGroup extends VscElement {
       <div class="wrapper">
         <slot
           @slotchange=${this._onSlotChange}
-          @vsc-change=${this._onChange}
+          @change=${this._onChange}
         ></slot>
       </div>
     `;


### PR DESCRIPTION
The `@vsc-change` custom event was deprecated and the radio group functionality is currently broken because of this.