### PR TITLE
Set _checkedRadio when default checked radio is found

### DIFF
--- a/src/vscode-radio-group/vscode-radio-group.ts
+++ b/src/vscode-radio-group/vscode-radio-group.ts
@@ -175,6 +175,7 @@ export class VscodeRadioGroup extends VscElement {
 
     if (indexOfDefaultCheckedRadio > -1) {
       this._radios[indexOfDefaultCheckedRadio].checked = true;
+      this._checkedRadio = indexOfDefaultCheckedRadio;
     }
   }
 


### PR DESCRIPTION
Without this change, #511 still reproduces, because the unchecking logic is based on `this._checkedRadio`, so we also need to update it on slot change.

Closes #511 