### PR TITLE
fix: reset stale selectedIndex when options shrink

### DIFF
--- a/dev/vscode-single-select/issue-530.html
+++ b/dev/vscode-single-select/issue-530.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>vscode-single-select stale index repro</title>
+    <link
+      rel="stylesheet"
+      href="/node_modules/@vscode/codicons/dist/codicon.css"
+      id="vscode-codicon-stylesheet"
+    />
+    <script type="module" src="/dist/main.js"></script>
+    <style>
+      body { font-family: sans-serif; padding: 16px; }
+      .row { margin: 8px 0; }
+      pre { background: #222; color: #ddd; padding: 8px; }
+      button { margin-right: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>vscode-single-select stale index repro</h1>
+    <div class="row">
+      <vscode-single-select id="sel" combobox></vscode-single-select>
+    </div>
+    <div class="row">
+      <button id="mount">Mount options</button>
+      <button id="select-two">Select "two"</button>
+      <button id="shrink">Shrink to placeholder</button>
+      <button id="read-value">Read value</button>
+    </div>
+    <pre id="out"></pre>
+
+    <script type="module">
+      const sel = document.getElementById('sel');
+      const out = document.getElementById('out');
+      const log = (m) => (out.textContent += m + "\n");
+
+      function mountOptions() {
+        sel.innerHTML = '';
+        const ph = document.createElement('vscode-option');
+        ph.value = '';
+        ph.textContent = 'placeholder';
+        const one = document.createElement('vscode-option');
+        one.value = 'one';
+        one.textContent = 'one';
+        const two = document.createElement('vscode-option');
+        two.value = 'two';
+        two.textContent = 'two';
+        sel.append(ph, one, two);
+      }
+
+      document.getElementById('mount').onclick = async () => {
+        mountOptions();
+        await sel.updateComplete;
+        log('Mounted options: placeholder, one, two');
+      };
+
+      document.getElementById('select-two').onclick = async () => {
+        sel.value = 'two';
+        await sel.updateComplete;
+        log(`selectedIndex=${sel.selectedIndex} value=${sel.value}`);
+      };
+
+      document.getElementById('shrink').onclick = async () => {
+        // React-like rerender: only placeholder remains
+        sel.innerHTML = '';
+        const only = document.createElement('vscode-option');
+        only.value = '';
+        only.textContent = 'placeholder';
+        sel.appendChild(only);
+        await sel.updateComplete;
+        log(`After shrink: selectedIndex=${sel.selectedIndex}`);
+      };
+
+      document.getElementById('read-value').onclick = () => {
+        try {
+          log(`value read: "${sel.value}"`);
+        } catch (e) {
+          log('ERROR reading value: ' + (e && e.stack ? e.stack : e));
+          throw e;
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/src/includes/vscode-select/OptionListController.ts
+++ b/src/includes/vscode-select/OptionListController.ts
@@ -68,7 +68,7 @@ export class OptionListController implements ReactiveController {
   }
 
   set selectedIndex(index: number) {
-    if (this._selectedIndex !== -1) {
+    if (this._selectedIndex !== -1 && this._options[this._selectedIndex]) {
       this._options[this._selectedIndex].selected ??= false;
     }
 
@@ -114,10 +114,12 @@ export class OptionListController implements ReactiveController {
   get value(): string | string[] {
     if (this._multiSelect) {
       return this._selectedIndexes.size > 0
-        ? Array.from(this._selectedIndexes).map((v) => this._options[v].value)
+        ? Array.from(this._selectedIndexes)
+            .filter((i) => i >= 0 && i < this._options.length)
+            .map((v) => this._options[v].value)
         : [];
     } else {
-      return this._selectedIndex > -1
+      return this._selectedIndex > -1 && this._selectedIndex < this._options.length
         ? this._options[this._selectedIndex].value
         : '';
     }
@@ -242,6 +244,9 @@ export class OptionListController implements ReactiveController {
     this._indexByValue.clear();
     this._indexByLabel.clear();
     this._numOfVisibleOptions = 0;
+    this._selectedIndex = -1;
+    this._selectedIndexes.clear();
+    this._activeIndex = -1;
   }
 
   getIsIndexSelected(index: number) {

--- a/src/vscode-single-select/vscode-single-select.test.ts
+++ b/src/vscode-single-select/vscode-single-select.test.ts
@@ -400,6 +400,51 @@ describe('vscode-single-select', () => {
       expect(el.shadowRoot?.querySelector('.combobox-face')).to.be.ok;
     });
 
+    it('clamps selection when options shrink (fixed)', async () => {
+      const el = await fixture<VscodeSingleSelect>(html`
+        <vscode-single-select combobox></vscode-single-select>
+      `);
+
+      // Append options dynamically to mimic React rendering
+      const placeholder = document.createElement('vscode-option') as VscodeOption;
+      placeholder.value = '';
+      placeholder.textContent = 'placeholder';
+      el.appendChild(placeholder);
+
+      const op1 = document.createElement('vscode-option') as VscodeOption;
+      op1.value = 'one';
+      op1.textContent = 'one';
+      el.appendChild(op1);
+
+      const op2 = document.createElement('vscode-option') as VscodeOption;
+      op2.value = 'two';
+      op2.textContent = 'two';
+      el.appendChild(op2);
+
+      await aTimeout(0);
+      await el.updateComplete;
+
+      // Select "two"
+      el.value = 'two';
+      expect(el.selectedIndex).to.eq(2);
+      await el.updateComplete;
+
+      // Shrink options to only the placeholder (React-like rerender)
+      el.innerHTML = '';
+      await aTimeout(0);
+      await el.updateComplete;
+
+      const onlyPlaceholder = document.createElement('vscode-option') as VscodeOption;
+      onlyPlaceholder.value = '';
+      onlyPlaceholder.textContent = 'placeholder';
+      el.appendChild(onlyPlaceholder);
+      await aTimeout(0);
+      await el.updateComplete;
+
+      expect(el.selectedIndex).to.eq(-1);
+      expect(el.value).to.eq('');
+    });
+
     it('filtered list', async () => {
       const el = await fixture<VscodeSingleSelect>(html`
         <vscode-single-select combobox>


### PR DESCRIPTION
Reading value could throw after dynamically reducing options. If the selected index exceeds the new option count, clear/clamp selection to a valid state to prevent crashes.

For example, when React dynamically renders options for the select.

Closes vscode-elements/elements#530