### PR TITLE
Fixed `vscolde-single-select` value not updated after onOptionClick event

### DIFF
--- a/src/vscode-single-select/vscode-single-select.ts
+++ b/src/vscode-single-select/vscode-single-select.ts
@@ -1,10 +1,10 @@
-import {html, LitElement, TemplateResult} from 'lit';
-import {property, query} from 'lit/decorators.js';
-import {ifDefined} from 'lit/directives/if-defined.js';
-import {customElement} from '../includes/VscElement.js';
-import {chevronDownIcon} from '../includes/vscode-select/template-elements.js';
-import {VscodeSelectBase} from '../includes/vscode-select/vscode-select-base.js';
-import {AssociatedFormControl} from '../includes/AssociatedFormControl.js';
+import { html, LitElement, TemplateResult } from 'lit';
+import { property, query } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { AssociatedFormControl } from '../includes/AssociatedFormControl.js';
+import { customElement } from '../includes/VscElement.js';
+import { chevronDownIcon } from '../includes/vscode-select/template-elements.js';
+import { VscodeSelectBase } from '../includes/vscode-select/vscode-select-base.js';
 import styles from './vscode-single-select.styles.js';
 
 export type VscSingleSelectCreateOptionEvent = CustomEvent<{value: string}>;
@@ -314,7 +314,7 @@ export class VscodeSingleSelect
       this._opts.selectedIndex = Number((optEl as HTMLElement).dataset.index);
 
       this.open = false;
-      this._internals.setFormValue(this._value);
+      this._internals.setFormValue(this._opts.value as string);
       this._manageRequired();
       this._dispatchChangeEvent();
     }


### PR DESCRIPTION
While using a `vscolde-single-select` element and changing it's value by clicking, it's value in its parent form is always ''.
This issue can easly be reproduced from [this documentation example](https://vscode-elements.github.io/guides/working-with-forms/#processing-form-data).
<img width="421" height="502" alt="image" src="https://github.com/user-attachments/assets/8cf448ba-da6e-42e2-b43b-79dcded83ac0" />


This PR fixes this by passing the actual selected value to the form.