### PR TITLE
Fix vscode-radio: use native radio input type

### DIFF
--- a/src/vscode-radio/vscode-radio.ts
+++ b/src/vscode-radio/vscode-radio.ts
@@ -320,12 +320,13 @@ export class VscodeRadio
     });
 
     return html`
-      <div class="wrapper">
+      <div class="wrapper">    
         <input
           ?autofocus=${this.autofocus}
           id="input"
           class="radio"
-          type="checkbox"
+          type="radio"
+          name=${this.name}
           ?checked=${this.checked}
           value=${this.value}
           tabindex=${this.tabIndex}

--- a/src/vscode-radio/vscode-radio.ts
+++ b/src/vscode-radio/vscode-radio.ts
@@ -320,7 +320,7 @@ export class VscodeRadio
     });
 
     return html`
-      <div class="wrapper">    
+      <div class="wrapper">
         <input
           ?autofocus=${this.autofocus}
           id="input"


### PR DESCRIPTION
Fixes vscode-elements/elements#612: https://github.com/vscode-elements/elements/issues/612


- Internal <input> inside <vscode-radio> is now type="radio" instead of "checkbox"
- Screen readers announce "radio button" instead of "checkbox"
- Manual verification done via DevTools + Windows Narrator

Tested via `via /dev/vscode-radio-group/checked.html`