### PR TITLE
Fix vscode-radio-group: dispatch change event on arrow key selection

### DIFF
--- a/src/vscode-radio-group/vscode-radio-group.ts
+++ b/src/vscode-radio-group/vscode-radio-group.ts
@@ -114,8 +114,7 @@ export class VscodeRadioGroup extends VscElement {
 
     if (listenedKeys.includes(key)) {
       ev.preventDefault();
-    }
-    else {
+    } else {
       return;
     }
 
@@ -127,9 +126,11 @@ export class VscodeRadioGroup extends VscElement {
       this._checkPrev();
     }
 
-    const checkedRadio = this._radios.find(r => r.checked);
+    const checkedRadio = this._radios.find((r) => r.checked);
     if (checkedRadio) {
-      checkedRadio.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
+      checkedRadio.dispatchEvent(
+        new Event('change', {bubbles: true, composed: true})
+      );
     }
   };
 

--- a/src/vscode-radio-group/vscode-radio-group.ts
+++ b/src/vscode-radio-group/vscode-radio-group.ts
@@ -115,6 +115,9 @@ export class VscodeRadioGroup extends VscElement {
     if (listenedKeys.includes(key)) {
       ev.preventDefault();
     }
+    else {
+      return;
+    }
 
     if (key === 'ArrowRight' || key === 'ArrowDown') {
       this._checkNext();
@@ -122,6 +125,11 @@ export class VscodeRadioGroup extends VscElement {
 
     if (key === 'ArrowLeft' || key === 'ArrowUp') {
       this._checkPrev();
+    }
+
+    const checkedRadio = this._radios.find(r => r.checked);
+    if (checkedRadio) {
+      checkedRadio.dispatchEvent(new Event('change', {bubbles: true, composed: true}));
     }
   };
 


### PR DESCRIPTION
Fixes #613

Arrow key navigation in <vscode-radio-group> updates the checked radio visually
but does not dispatch a change event. This differs from native radio behavior
and prevents keyboard-driven selection changes from being observed by consumers.

This PR:
- Keeps existing arrow key behavior (move + select)
- Dispatches a bubbling, composed 'change' event from the newly checked radio
- No behavior change for mouse or Space key interaction.