### PR TITLE
build: import decorator helpers from tslib (importHelpers)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@lit/context": "^1.1.3",
-        "lit": "^3.2.1"
+        "lit": "^3.2.1",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@bendera/wds-plugin-directory-index": "^0.7.0",
@@ -13439,7 +13440,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsscmp": {
@@ -23858,8 +23858,7 @@
     "tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
   "homepage": "https://vscode-elements.github.io",
   "dependencies": {
     "@lit/context": "^1.1.3",
-    "lit": "^3.2.1"
+    "lit": "^3.2.1",
+    "tslib": "^2.8.1"
   },
   "peerDependencies": {
     "@vscode/codicons": ">=0.0.40"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
     "types": ["mocha"]


### PR DESCRIPTION
## Summary

Enable `importHelpers` in `tsconfig.json` and add `tslib` as a dependency, so the TypeScript decorator helpers are imported from `tslib` rather than inlined into every emitted file.

## Motivation

With `importHelpers: false` (the default), `tsc` inlines the helper into every file that uses decorators, guarded by a top-level `this`:

```js
var __decorate = (this && this.__decorate) || function () { ... };
```

That top-level `this` is fine at runtime (in an ES module it's `undefined`, so the guard falls back to the inline helper), but it makes bundlers flag it. Consumers bundling the library with Rollup get, for **all 41 component files**:

```
(!) "this" has been rewritten to "undefined"
https://rollupjs.org/troubleshooting/#error-this-is-undefined
```

## Fix

Setting `importHelpers: true` makes `tsc` emit `import { __decorate } from "tslib";` instead — no top-level `this`, so no bundler warning for consumers, and the helper is imported once from `tslib` rather than inlined into every file.

## Verification

- `npm run build` succeeds.
- After the change, `0` dist files contain the `this && this.__decorate` prologue; `41` now `import { __decorate } from "tslib"`.
- `npm test` — 399 passed, 0 failed, 25 skipped.